### PR TITLE
Improve docs and plugin metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ zip -r jouwplugin.zip jouwplugin/
 4. Klaar! De plugin wordt automatisch zichtbaar in `unofficial/plugins.json`
 5. Wil je officiële opname? Dien dan een PR in naar `/official/`
 
+### Structuur van een plugin
+Een minimale plugin bevat de volgende bestanden:
+
+```
+myplugin/
+├─ main.py        # bevat class PluginWidget(QWidget)
+├─ metadata.json  # naam, slug, versie, beschrijving, auteur
+├─ icon.png       # optioneel pictogram
+└─ preview.jpg    # optionele screenshot
+```
+
+`metadata.json` wordt gebruikt door de Plugin Store om details en tags te tonen.
+
 ---
 
 ## 🧹 plugin.json format

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -1,6 +1,6 @@
 **🌐 Verfügbare Sprachen:** [Nederlands](../README.md) | [English](README_EN.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [中文](README_ZH.md)
 
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="theme.css">
 
 # 🧹 Hauswerk Plugins (Deutsch)
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -1,6 +1,6 @@
 **🌐 Available Languages:** [../Nederlands](README.md) | [English](README_EN.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [中文](README_ZH.md)
 
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="theme.css">
 
 # 🧹 Hauswerk Plugins
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -1,6 +1,6 @@
 **🌐 Langues disponibles:** [Nederlands](../README.md) | [English](README_EN.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [中文](README_ZH.md)
 
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="theme.css">
 
 # 🧹 Plugins Hauswerk (Français)
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -1,6 +1,6 @@
 **🌐 支持语言:** [Nederlands](../README.md) | [English](README_EN.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [中文](README_ZH.md)
 
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="theme.css">
 
 # 🧹 Hauswerk 插件（中文）
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: Hauswerk Plugin Store
 layout: default
 ---
 
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="theme.css">
 
 # 🧰 Hauswerk Plugin Store
 

--- a/docs/layouts/default.html
+++ b/docs/layouts/default.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>{{ page.title }}</title>
-  <link rel="stylesheet" href="/hauswerk-plugins/docs/style.css">
+  <link rel="stylesheet" href="/hauswerk-plugins/docs/theme.css">
 </head>
 <body>
   <header>

--- a/official/psychotisch/main.py
+++ b/official/psychotisch/main.py
@@ -1,4 +1,4 @@
-# widgets/psychotisch_tab.py
+"""Psychotisch video mashup plugin for Hauswerk."""
 
 import os
 import random
@@ -193,3 +193,9 @@ class PsychotischTab(QWidget):
             except: pass
         try: os.remove(concatlist)
         except: pass
+
+# Alias for Hauswerk loader
+class PluginWidget(PsychotischTab):
+    """Entry point for Hauswerk."""
+    pass
+

--- a/official/psychotisch/metadata.json
+++ b/official/psychotisch/metadata.json
@@ -1,8 +1,12 @@
 {
   "name": "Psychotisch",
-  "entry": "psychotisch.py",
-  "class": "PsychotischWidget",
+  "slug": "psychotisch",
+  "version": "1.0",
+  "description": "Chaotic multi-layer video generator.",
+  "author": "Unknown",
+  "entry": "main.py",
+  "class": "PluginWidget",
   "icon": "psychotisch.svg",
-  "tags": [],
+  "tags": ["video", "effect"],
   "verified": true
-}
+} 


### PR DESCRIPTION
## Summary
- fix psychotisch plugin metadata and add PluginWidget alias
- use `theme.css` as stylesheet for docs layout
- fix stylesheet links in documentation
- document plugin folder structure in README

## Testing
- `python -m py_compile official/psychotisch/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6878dbbfc6bc832287cfcfad69daa288