### PR TITLE
Clarify screenshot conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Alle plugins bevatten minimaal:
 - Één `.py` bestand met een `QWidget` subclass
 - Een `plugin.json` bestand met metadata
 - Een `.svg` icoon (optioneel)
-- (optioneel) `preview.png` (wordt getoond in GUI)
+- (optioneel) `preview.jpg` (wordt getoond in GUI)
 - (optioneel) `tags`: lijst met trefwoorden zoals `"video"`, `"audio"`, `"glitch"`
 
 ---
@@ -110,7 +110,7 @@ Zo kunnen er officiële én experimentele stores tegelijk actief zijn in de inte
    - `jouwplugin.py`
    - `plugin.json`
    - (optioneel) `icoon.svg`
-   - (optioneel) `preview.png`
+   - (optioneel) `preview.jpg`
 
 2. Zip de hele pluginmap:
 ```bash

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,0 +1,19 @@
+# 📤 Plugin upload
+
+Follow these steps to share your plugin:
+
+1. Create a folder containing:
+   - `main.py` with your `PluginWidget` class
+   - `metadata.json` with plugin details
+   - `icon.png` (optional)
+   - `preview.jpg` (optional screenshot)
+2. Zip the folder, e.g. `myplugin.zip`.
+3. Place the `.zip` in `/unofficial/` or `/official/` depending on your submission.
+4. **Include `preview.jpg` inside the zip and list it in `metadata.json`:**
+   ```json
+   {
+     "name": "MyPlugin",
+     "preview": "preview.jpg"
+   }
+   ```
+   The store reads this property to display your screenshot.


### PR DESCRIPTION
## Summary
- standardize screenshot file name to `preview.jpg` in README
- add plugin upload guide documenting screenshot reference

## Testing
- `python -m py_compile unpack_plugins.py generate_previews.py`

------
https://chatgpt.com/codex/tasks/task_e_6878eb9f76fc8322837f20faa79597f4