### PR TITLE
Add Theme Shop and unify store

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Welkom bij de **Hauswerk Plugins** repository — de officiële opslagplek voor uitbreidbare tools binnen de [Hauswerk](https://github.com/michligtenberg2/Hauswerk) GUI.
 
-Deze repository bevat kant-en-klare plugins als `.zip` bestanden, samen met een centrale `plugins.json` die automatisch gebruikt wordt door de Plugin Store-tab binnen de Hauswerk-app.
+Deze repository bevat kant-en-klare plugins als `.zip` bestanden. De bestanden `plugins.json` en `themes.json` voeden de Plugin Store en Theme Shop binnen de Hauswerk-app.
 
 ---
 
@@ -22,6 +22,8 @@ Deze repository bevat kant-en-klare plugins als `.zip` bestanden, samen met een 
 | Psychotisch     | Creeër gekke EBM-style montage           | `psychotisch.zip` |
 | AudioFadeBPM    | Batch audio extractie + crossfade        | `audiofadebpm.zip` |
 | UIBuilder       | Visuele UI-pluginbouwer                  | `uibuilder.zip` |
+
+Naast plugins vind je in deze repo ook thema's voor de Hauswerk-interface. Deze zijn te bekijken in de [Theme Shop](docs/theme_browser.html).
 
 Alle plugins bevatten minimaal:
 - Één `.py` bestand met een `QWidget` subclass

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,8 @@
+---
+title: Documentatie
+layout: default
+---
+
+# 📚 Documentatie
+
+Overzicht van alle handleidingen voor plugins en themes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,11 @@
         🔍 Open Plugin Browser
       </a>
 
+      <h2>🎨 Themes</h2>
+      <a href="theme_browser.html" class="button" style="font-size:1.1rem; padding: 1rem; display: inline-block; border: 2px solid black; background: #000; color: #fff; margin-bottom: 1rem;">
+        🛍️ Open Theme Shop
+      </a>
+
       <p><strong>⚠️ Deze browser bevat officiële én community plugins.</strong><br>
       Je kunt filteren op tags, validatie, naam of functie.</p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,14 @@ Welkom bij de officiële plugin-index voor de **Hauswerk** applicatie.
 🔍 Open Plugin Browser
 </a>
 
+## 🎨 Themes
+
+Ontdek nieuwe thema's in de Theme Shop:
+
+<a href="theme_browser.html" class="button" style="font-size:1.1rem; padding: 1rem; display: inline-block; border: 2px solid black; background: #000; color: #fff; margin-bottom: 1rem;">
+🛍️ Open Theme Shop
+</a>
+
 > ⚠️ Deze browser bevat **officiële** én **community plugins**. Je kunt filteren op tags, validatie, naam of functie.
 
 ---

--- a/docs/layouts/default.html
+++ b/docs/layouts/default.html
@@ -4,10 +4,22 @@
   <meta charset="UTF-8">
   <title>{{ page.title }}</title>
   <link rel="stylesheet" href="/hauswerk-plugins/docs/theme.css">
+  <script defer src="/hauswerk-plugins/docs/darkmode_toggle.js"></script>
 </head>
 <body>
   <header>
-    <h1>🛠️ Hauswerk Plugin Store</h1>
+    <nav class="navbar">
+      <div class="nav-brand">Hauswerk</div>
+      <button id="menu-toggle" class="mobile-toggle">☰</button>
+      <div class="nav-links">
+        <a href="/hauswerk-plugins/docs/index.html">Home</a>
+        <a href="/hauswerk-plugins/docs/plugin_browser.html">Plugins</a>
+        <a href="/hauswerk-plugins/docs/theme_browser.html">Themes</a>
+        <a href="/hauswerk-plugins/docs/upload.html">Upload</a>
+        <a href="/hauswerk-plugins/docs/doc.html">Docs</a>
+        <button onclick="toggleDarkMode()">🌓</button>
+      </div>
+    </nav>
     <nav class="language-selector">
       <a href="/hauswerk-plugins/README.md">🇳🇱 NL</a>
       <a href="/hauswerk-plugins/docs/README_EN.md">🇬🇧 EN</a>

--- a/docs/plugin_browser.html
+++ b/docs/plugin_browser.html
@@ -16,9 +16,10 @@
     <button id="menu-toggle" class="mobile-toggle">☰</button>
     <div class="nav-links">
       <a href="index.html">Home</a>
-      <a href="plugin_browser.html" class="active">Browser</a>
-      <a href="viewer.html">Viewer</a>
-      <a href="README.md">Docs</a>
+      <a href="plugin_browser.html" class="active">Plugins</a>
+      <a href="theme_browser.html">Themes</a>
+      <a href="upload.html">Upload</a>
+      <a href="doc.html">Docs</a>
       <button onclick="toggleDarkMode()">🌓</button>
     </div>
   </nav>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,10 @@
+---
+title: Plugins
+layout: default
+---
+
+# 🔌 Plugins
+
+Hier vind je informatie over het installeren en maken van plugins voor Hauswerk.
+
+Bezoek de [Plugin Browser](plugin_browser.html) om alle beschikbare plugins te bekijken.

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -181,3 +181,37 @@ footer {
 html.dark footer {
   color: #666;
 }
+
+/* Cards voor plugins en themes */
+.plugin-card {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem;
+  background: #fff;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+  margin-bottom: 1.5rem;
+  transition: transform 0.2s ease;
+}
+
+.plugin-card:hover {
+  transform: translateY(-4px);
+}
+
+.plugin-card img {
+  border-radius: 12px;
+  margin-bottom: 0.5rem;
+}
+
+.filters .filter-button {
+  display: inline-block;
+  background: var(--border);
+  padding: 0.2rem 0.6rem;
+  margin: 0 0.25rem 0.25rem 0;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.filters .filter-button.active {
+  background: var(--accent);
+  color: #fff;
+}

--- a/docs/theme_browser.html
+++ b/docs/theme_browser.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hauswerk Theme Shop</title>
+  <link rel="stylesheet" href="theme.css">
+  <script defer src="darkmode_toggle.js"></script>
+  <script defer src="theme_data.js"></script>
+  <script defer src="theme_browser.js"></script>
+</head>
+<body>
+  <nav class="navbar">
+    <div class="nav-brand">Hauswerk</div>
+    <button id="menu-toggle" class="mobile-toggle">☰</button>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="plugin_browser.html">Plugins</a>
+      <a href="theme_browser.html" class="active">Themes</a>
+      <a href="upload.html">Upload</a>
+      <a href="doc.html">Docs</a>
+      <button id="dark-toggle" class="button" onclick="toggleDarkMode()">🌓</button>
+    </div>
+  </nav>
+
+  <div class="container">
+    <main>
+      <div style="display:flex;gap:1rem;align-items:center;margin-bottom:1rem;flex-wrap:wrap;">
+        <input type="text" id="searchInput" placeholder="Zoek themes..." class="search-input">
+      </div>
+      <div class="filters" id="tagFilters" style="margin-bottom:1rem;"></div>
+      <div id="pluginContainer"></div>
+
+      <div id="previewOverlay" class="preview-overlay" style="display:none">
+        <img id="previewImage" src="">
+      </div>
+    </main>
+  </div>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 Hauswerk. Gemaakt met liefde voor themes.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/theme_browser.js
+++ b/docs/theme_browser.js
@@ -1,0 +1,77 @@
+// Theme Shop browser
+function getActiveTags() {
+  return [...document.querySelectorAll('.filter-button.active')].map(b => b.innerText);
+}
+
+function uniqueTags(items) {
+  const all = items.flatMap(p => p.tags || []);
+  return [...new Set(all)];
+}
+
+function renderTagFilters() {
+  const filterDiv = document.getElementById('tagFilters');
+  const tags = uniqueTags(window.themes);
+  filterDiv.innerHTML = '';
+  tags.forEach(tag => {
+    const btn = document.createElement('span');
+    btn.className = 'filter-button';
+    btn.innerText = tag;
+    btn.onclick = () => {
+      btn.classList.toggle('active');
+      renderThemes(document.getElementById('searchInput').value);
+    };
+    filterDiv.appendChild(btn);
+  });
+}
+
+function renderThemes(filter = '') {
+  const container = document.getElementById('pluginContainer');
+  container.innerHTML = '';
+  const q = filter.toLowerCase();
+  const activeTags = getActiveTags();
+  let count = 0;
+  let sorted = [...window.themes];
+  sorted.sort((a, b) => a.name.localeCompare(b.name));
+  sorted.forEach(t => {
+    const matchQuery =
+      t.name.toLowerCase().includes(q) ||
+      t.tags.join(' ').toLowerCase().includes(q) ||
+      (t.description || '').toLowerCase().includes(q);
+    const matchTags = activeTags.length === 0 || activeTags.every(x => t.tags.includes(x));
+    if (matchQuery && matchTags) {
+      count++;
+      const card = document.createElement('div');
+      card.className = 'plugin-card';
+      const tags = t.tags.map(tag => `<span class='tag'>${tag}</span>`).join(' ');
+      const jsonStr = JSON.stringify(t, null, 2);
+      card.innerHTML = `
+        <h2>${t.name} ${tags}</h2>
+        <img src="${t.preview}" alt="preview" style="width:100%;max-width:400px;cursor:pointer;" onclick="showPreview('${t.preview}')">
+        <p>${t.description}</p>
+        <p><a class="button" href="${t.zip_url}" download>Download</a>
+           <button onclick='copyJSON(`${jsonStr}`)'>JSON</button></p>
+        <details><summary>Bekijk JSON</summary><pre><code>${jsonStr}</code></pre></details>
+      `;
+      container.appendChild(card);
+    }
+  });
+  document.getElementById('pluginCount').innerText = `(${count})`;
+}
+
+function copyJSON(text) {
+  navigator.clipboard.writeText(text).then(() => alert('Gekopieerd!'));
+}
+
+function showPreview(src) {
+  const overlay = document.getElementById('previewOverlay');
+  document.getElementById('previewImage').src = src;
+  overlay.style.display = 'flex';
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  renderTagFilters();
+  renderThemes();
+  document.getElementById('searchInput').addEventListener('input', e => {
+    renderThemes(e.target.value);
+  });
+});

--- a/docs/theme_data.js
+++ b/docs/theme_data.js
@@ -1,0 +1,7 @@
+fetch("https://raw.githubusercontent.com/michligtenberg2/hauswerk-plugins/main/themes.json")
+  .then(res => res.json())
+  .then(data => {
+    window.themes = data;
+    renderTagFilters();
+    renderThemes();
+  });

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,8 @@
+---
+title: Themes
+layout: default
+---
+
+# 🎨 Themes
+
+Alles over thema's voor Hauswerk. Bekijk het aanbod in de [Theme Shop](theme_browser.html).

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,0 +1,12 @@
+---
+title: Upload
+layout: default
+---
+
+# ⬆️ Upload
+
+Volg deze stappen om je eigen plugin of thema te uploaden.
+
+1. Maak een ZIP-bestand volgens de documentatie.
+2. Voeg een `metadata.json` toe met naam, versie en auteur.
+3. Maak een pull request naar deze repository.

--- a/themes.json
+++ b/themes.json
@@ -1,0 +1,22 @@
+[
+  {
+    "slug": "dark-minimal",
+    "name": "Dark Minimal",
+    "description": "Donker minimalistisch thema",
+    "version": "1.0",
+    "author": "Hauswerk Team",
+    "tags": ["dark", "minimal"],
+    "preview": "https://via.placeholder.com/600x400?text=Dark+Minimal",
+    "zip_url": "https://example.com/themes/dark-minimal.zip"
+  },
+  {
+    "slug": "light-elegant",
+    "name": "Light Elegant",
+    "description": "Licht en elegant thema",
+    "version": "1.0",
+    "author": "Community",
+    "tags": ["light", "elegant"],
+    "preview": "https://via.placeholder.com/600x400?text=Light+Elegant",
+    "zip_url": "https://example.com/themes/light-elegant.zip"
+  }
+]


### PR DESCRIPTION
## Summary
- introduce `themes.json` to index downloadable themes
- add new Theme Shop pages using same style as Plugin Browser
- extend navigation layout and plugin browser with new links
- document theme support and upload instructions
- style plugin/theme cards in `theme.css`

## Testing
- `python3 -m json.tool plugins.json`
- `python3 -m json.tool themes.json`


------
https://chatgpt.com/codex/tasks/task_e_6878f0fe7c208322945f967236849887